### PR TITLE
Identify records of interest in NGD_AL.

### DIFF
--- a/ngdal_roi.py
+++ b/ngdal_roi.py
@@ -1,0 +1,26 @@
+# Compare the redline NGD_AL data against the source data to detect changes
+
+import geopandas as gpd
+
+# paths
+redline_path = '../redline_ngdal.geojson'
+
+ngd_db_path = '../ngd_national.gdb'
+ngdal_layer = 'WC2021NGD_AL_20200313'
+
+# read the redline data and get a list of attributes that have changed
+print("Reading redline data")
+rdf = gpd.read_file(redline_path)
+# make a list of the NGD_UIDs that have changed so that we can filter the NGD_AL later
+# null will end up in this list, but that won't hurt later
+modified_ngduids = rdf['NGD_UID'].unique().tolist()
+
+# read the NGD_AL source data, but only keep records that are in the redline layer
+print("Reading NGD_AL")
+ngdal = gpd.read_file(ngd_db_path, layer=ngdal_layer)
+print("Filtering NGD_AL to only modified records")
+ngdal = ngdal.loc[ngdal['NGD_UID'].isin(modified_ngduids)]
+
+# write out the NGD_AL records that have an entry in the redline data
+print("Writing records that have a correlated redline entry")
+ngdal.to_file("../ngdal_affected.geojson", driver='GeoJSON')

--- a/ngdal_roi.py
+++ b/ngdal_roi.py
@@ -1,4 +1,4 @@
-# Compare the redline NGD_AL data against the source data to detect changes
+# Compare the redline NGD_AL data against the source data to extract only records of interest for change detection
 
 import geopandas as gpd
 

--- a/separate_ngd_al_street.py
+++ b/separate_ngd_al_street.py
@@ -57,9 +57,9 @@ df = gpd.read_file(data_path)
 
 # separate the redline data into its component datasets in EC
 ngdal = df[ngdal_cols].rename(columns=ngdal_col_map)
-ngdal.to_file("../ngdal.geojson", driver='GeoJSON')
+ngdal.to_file("../redline_ngdal.geojson", driver='GeoJSON')
 
 ngdstreet = pd.DataFrame(df[ngdstreet_cols]).rename(columns=ngdstreet_col_map)
 
 # should the alias values be stacked to align with the name columns? EC has no alias values.
-ngdstreet.to_csv("../ngd_street.csv", index=False)
+ngdstreet.to_csv("../redline_ngd_street.csv", index=False)

--- a/separate_ngd_al_street.py
+++ b/separate_ngd_al_street.py
@@ -1,0 +1,65 @@
+# Break a layer apart into either the NGD_AL or NGD_STREET components
+
+import geopandas as gpd
+import pandas as pd
+
+# fields used for tracking within AGOL
+special_cols = ['GlobalID','CreationDate','Creator','EditDate','Editor', 'Comments']
+
+# columns that belong to NGD_AL, mapped to their standard names
+ngdal_col_map = {'WC2021NGD_AL_20200313_NGD_UID': 'NGD_UID',
+    'WC2021NGD_AL_20200313_SGMNT_TYP': 'SGMNT_TYP_CDE',
+    'WC2021NGD_AL_20200313_SGMNT_SRC': 'SGMNT_SRC',
+    'WC2021NGD_AL_20200313_STR_CLS_C': 'STR_CLS_CDE',
+    'WC2021NGD_AL_20200313_STR_RNK_C': 'STR_RNK_CDE',
+    'WC2021NGD_AL_20200313_AFL_VAL': 'AFL_VAL',
+    'WC2021NGD_AL_20200313_AFL_SFX': 'AFL_SFX',
+    'WC2021NGD_AL_20200313_AFL_SRC': 'AFL_SRC',
+    'WC2021NGD_AL_20200313_ATL_VAL': 'ATL_VAL',
+    'WC2021NGD_AL_20200313_ATL_SFX': 'ATL_SFX',
+    'WC2021NGD_AL_20200313_ATL_SRC': 'ATL_SRC',
+    'WC2021NGD_AL_20200313_AFR_VAL': 'AFR_VAL',
+    'WC2021NGD_AL_20200313_AFR_SFX': 'AFR_SFX',
+    'WC2021NGD_AL_20200313_AFR_SRC': 'AFR_SRC',
+    'WC2021NGD_AL_20200313_ATR_VAL': 'ATR_VAL',
+    'WC2021NGD_AL_20200313_ATR_SFX': 'ATR_SFX',
+    'WC2021NGD_AL_20200313_ATR_SRC': 'ATR_SRC',
+    'WC2021NGD_AL_20200313_ADDR_TYP_': 'ADDR_TYP_L',
+    'WC2021NGD_AL_20200313_ADDR_TYP1': 'ADDR_TYP_R',
+    'WC2021NGD_AL_20200313_ADDR_PRTY': 'ADDR_PRTY_L',
+    'WC2021NGD_AL_20200313_ADDR_PR_1': 'ADDR_PRTY_R'}
+
+# columns that belong to NGD_STREET, mapped to their standard names
+ngdstreet_col_map = {'WC2021NGD_STREET_202003_STR_N_1': 'STR_NME',
+    'WC2021NGD_STREET_202003_STR_TYP': 'STR_TYP',
+    'WC2021NGD_STREET_202003_STR_DIR': 'STR_DIR',
+    'WC2021NGD_STREET_202003_NAME_SR': 'NAME_SRC'}
+# in the DB these fields form their own records
+ngdstreet_extra_cols = ['STR_NME_ALIAS1','STR_TYP_ALIAS1','STR_DIR_ALIAS1','NAME_SRC_ALIAS1',
+                        'STR_NME_ALIAS2','STR_TYP_ALIAS2','STR_DIR_ALIAS2','NME_SRC_ALIAS2']
+
+# build the list of columns that will end up on each output
+ngdal_cols = []
+ngdal_cols.extend(special_cols)
+ngdal_cols.append('geometry')
+ngdal_cols.extend(ngdal_col_map.keys())
+print(ngdal_cols)
+
+ngdstreet_cols = []
+ngdstreet_cols.extend(special_cols)
+ngdstreet_cols.extend(ngdstreet_extra_cols)
+ngdstreet_cols.extend(ngdstreet_col_map.keys())
+print(ngdstreet_cols)
+
+# read the redline data
+data_path = "../redline_2020-04-17.geojson"
+df = gpd.read_file(data_path)
+
+# separate the redline data into its component datasets in EC
+ngdal = df[ngdal_cols].rename(columns=ngdal_col_map)
+ngdal.to_file("../ngdal.geojson", driver='GeoJSON')
+
+ngdstreet = pd.DataFrame(df[ngdstreet_cols]).rename(columns=ngdstreet_col_map)
+
+# should the alias values be stacked to align with the name columns? EC has no alias values.
+ngdstreet.to_csv("../ngd_street.csv", index=False)

--- a/separate_ngd_al_street.py
+++ b/separate_ngd_al_street.py
@@ -43,13 +43,11 @@ ngdal_cols = []
 ngdal_cols.extend(special_cols)
 ngdal_cols.append('geometry')
 ngdal_cols.extend(ngdal_col_map.keys())
-print(ngdal_cols)
 
 ngdstreet_cols = []
 ngdstreet_cols.extend(special_cols)
 ngdstreet_cols.extend(ngdstreet_extra_cols)
 ngdstreet_cols.extend(ngdstreet_col_map.keys())
-print(ngdstreet_cols)
 
 # read the redline data
 data_path = "../redline_2020-04-17.geojson"


### PR DESCRIPTION
A set of scripts to separate the redline layer into its NGD_AL and NGD_STREET components, and then compare the redline data against NGD_AL to extract a subset of records for further comparisons. The extracting of NGD_AL data is really just to make processing a lot easier, since we are generally going to be interested in less than 1% of all records.

Normally this would use data from the automated download, but I can't run that on my Mac due to using `arcpy` in the downloader. My input is just a manual extract here. I've been using geojson as the intermediate file format because it is vendor agnostic and the data is small enough to make it easier to work with, including in a normal text editor. We can pick a different format for final deliverables easily enough.